### PR TITLE
Rename top level module from top() to lpc_top()

### DIFF
--- a/lpcperipheral/lpcperipheral.py
+++ b/lpcperipheral/lpcperipheral.py
@@ -129,4 +129,4 @@ if __name__ == "__main__":
             top.dma_sel, top.dma_cyc, top.dma_stb, top.dma_we, top.dma_ack,
             top.lclk, top.lframe, top.lad_in,
             top.lad_out, top.lad_en, top.lreset, top.bmc_vuart_irq,
-            top.bmc_ipmi_irq, top.target_vuart_irq, top.target_ipmi_irq]))
+            top.bmc_ipmi_irq, top.target_vuart_irq, top.target_ipmi_irq], name="lpc_top"))


### PR DESCRIPTION
When integrating lpcperipheral into a project, top() is not a particularly
descriptive name, so rename it to lpc_top().

Signed-off-by: Anton Blanchard <anton@ozlabs.org>