### PR TITLE
LPC-CTRL fixes

### DIFF
--- a/lpcperipheral/ipmi_bt.py
+++ b/lpcperipheral/ipmi_bt.py
@@ -38,7 +38,7 @@ class IPMI_BT(Elaboratable):
     def __init__(self, depth=64):
         self.depth = depth
 
-        self.bmc_wb = WishboneInterface(data_width=8, addr_width=3)
+        self.bmc_wb = WishboneInterface(data_width=32, addr_width=3, granularity=8)
         self.bmc_irq = Signal()
 
         self.target_wb = WishboneInterface(data_width=8, addr_width=2)

--- a/lpcperipheral/lpc_ctrl.py
+++ b/lpcperipheral/lpc_ctrl.py
@@ -26,11 +26,11 @@ class LPC_Ctrl(Elaboratable):
         m = Module()
 
         base_lo_csr = CSRElement(32, "rw")
-        base_lo = Signal(32, reset=192*1024*1024)
+        base_lo = Signal(32)
         #  Leave space for upper 32 bits, unused for now
         base_hi_csr = CSRElement(32, "rw")
         mask_lo_csr = CSRElement(32, "rw")
-        mask_lo = Signal(32, reset=0x3FFFFFF)
+        mask_lo = Signal(32)
         #  Leave space for upper 32 bits, unused for now
         mask_hi_csr = CSRElement(32, "rw")
 
@@ -56,7 +56,7 @@ class LPC_Ctrl(Elaboratable):
 
         m.d.comb += [
             self.lpc_wb.connect(self.dma_wb),
-            # bask/mask are in bytes, so convert to wishbone addresses
+            # base/mask are in bytes, so convert to wishbone addresses
             self.dma_wb.adr.eq((self.lpc_wb.adr & (mask_lo >> 2)) | (base_lo >> 2))
         ]
 

--- a/lpcperipheral/lpcperipheral.py
+++ b/lpcperipheral/lpcperipheral.py
@@ -26,8 +26,8 @@ class LPCPeripheral(Elaboratable):
         # BMC wishbone. We dont use a Record because we want predictable
         # signal names so we can hook it up to VHDL/Verilog
         self.adr = Signal(14)
-        self.dat_w = Signal(8)
-        self.dat_r = Signal(8)
+        self.dat_w = Signal(32)
+        self.dat_r = Signal(32)
         self.sel = Signal()
         self.cyc = Signal()
         self.stb = Signal()

--- a/lpcperipheral/lpcperipheral.py
+++ b/lpcperipheral/lpcperipheral.py
@@ -98,8 +98,11 @@ class LPCPeripheral(Elaboratable):
             lpc_ctrl.dma_wb.dat_r.eq(self.dma_dat_r),
             lpc_ctrl.dma_wb.ack.eq(self.dma_ack),
 
-            # LPC to LPC CTRL wishbone
+            # LPC to LPC CTRL DMA wishbone
             lpc.fw_wb.connect(lpc_ctrl.lpc_wb),
+
+            # LPC CTRL I/O wishbone
+            io.lpc_ctrl_wb.connect(lpc_ctrl.io_wb),
 
             # LPC
             lpc.lclk.eq(self.lclk),

--- a/lpcperipheral/lpcperipheral.py
+++ b/lpcperipheral/lpcperipheral.py
@@ -2,7 +2,6 @@ from enum import Enum, unique
 
 from nmigen import Signal, Elaboratable, Module, Cat
 from nmigen.back import verilog
-from nmigen_soc.wishbone import Interface as WishboneInterface
 
 from .io_space import IOSpace
 from .lpc2wb import lpc2wb

--- a/lpcperipheral/vuart_joined.py
+++ b/lpcperipheral/vuart_joined.py
@@ -21,10 +21,10 @@ class VUartJoined(Elaboratable):
         self.depth = depth
 
         self.irq_a = Signal()
-        self.wb_a = WishboneInterface(data_width=8, addr_width=3)
+        self.wb_a = WishboneInterface(data_width=32, addr_width=3, granularity=8)
 
         self.irq_b = Signal()
-        self.wb_b = WishboneInterface(data_width=8, addr_width=3)
+        self.wb_b = WishboneInterface(data_width=8, addr_width=3, granularity=8)
 
     def elaborate(self, platform):
         m = Module()


### PR DESCRIPTION
The LPC CTRL I/O wishbone wasn't hooked up at all, and the BMC wishbone was only 8 bit (LPC-CTRL needs it to be 32 bit).